### PR TITLE
Groovytestkit 2

### DIFF
--- a/liferay-workspace/settings.gradle
+++ b/liferay-workspace/settings.gradle
@@ -11,3 +11,5 @@ buildscript {
 }
 
 apply plugin: "com.liferay.workspace"
+
+include 'tests'

--- a/liferay-workspace/tests/build.gradle
+++ b/liferay-workspace/tests/build.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'groovy'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testCompile 'org.codehaus.groovy:groovy-all:2.4.4'
+    testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
+	testCompile gradleTestKit()
+}
+
+check.dependsOn ':blade-tests:initBundle'
+check.mustRunAfter ':liferay-workspace/modules:build'

--- a/liferay-workspace/tests/build.gradle
+++ b/liferay-workspace/tests/build.gradle
@@ -5,10 +5,18 @@ repositories {
 }
 
 dependencies {
-    testCompile 'org.codehaus.groovy:groovy-all:2.4.4'
-    testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
-	testCompile gradleTestKit()
+	compile group: "biz.aQute.bnd", name: "biz.aQute.bnd", version: "3.1.0"
+	compile group: "com.squareup.okhttp3", name: "okhttp", version: "3.3.1"
+	compile group: "de.undercouch", name: "gradle-download-task", version: "2.1.0"
+    compile group: "org.codehaus.groovy", name: "groovy-all", version: "2.4.4"
+	compile group: "org.eclipse.core", name: "runtime", version: "3.10.0-v20140318-2214"
+    compile group: "org.spockframework", name: "spock-core", version: "1.0-groovy-2.4"
+	compile gradleApi()
+	compile gradleTestKit()
 }
 
-check.dependsOn ':blade-tests:initBundle'
-check.mustRunAfter ':liferay-workspace/modules:build'
+//check.dependsOn 'initBundle'
+//test.dependsOn 'build'
+
+
+

--- a/liferay-workspace/tests/src/test/groovy/com/liferay/blade/tests/BladeTests.groovy
+++ b/liferay-workspace/tests/src/test/groovy/com/liferay/blade/tests/BladeTests.groovy
@@ -1,0 +1,132 @@
+package com.liferay.blade.tests
+
+import org.gradle.testkit.runner.GradleRunner
+import static org.gradle.testkit.runner.TaskOutcome.*
+import spock.lang.Specification
+import de.undercouch.gradle.tasks.download.Download;
+import java.util.jar.JarInputStream;
+import java.io.FileNotFoundException;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Request.Builder;
+import aQute.bnd.osgi.Jar;
+
+class BladeTests extends Specification {
+	public void executeBlade(String[] args) {
+		"java -jar build/${bladeclijar} args".execute()
+	}
+
+	def setup () {
+	    private static String getLatestRemoteBladeCLIJar() throws BladeCLIException
+	    {
+	        _settingsDir.mkdirs();
+	        repoCache.mkdirs();
+
+	        Processor reporter = new Processor();
+	        FixedIndexedRepo repo = new FixedIndexedRepo();
+	        Map<String, String> props = new HashMap<String, String>();
+	        props.put( "name", "index1" );
+	        props.put( "locations", getRepoURL()+"index.xml.gz" );
+	        props.put( FixedIndexedRepo.PROP_CACHE, repoCache.getAbsolutePath() );
+
+	        repo.setProperties( props );
+	        repo.setReporter( reporter );
+
+	        try
+	        {
+	            File[] files = repo.get( "com.liferay.blade.cli", "[1,2)" );
+
+	            File cliJar = files[0];
+
+	            cachedBladeCLIPath = new Path( cliJar.getCanonicalPath() );
+
+	            return cliJar.getName();
+	        }
+	        catch( Exception e )
+	        {
+	            throw new BladeCLIException( "Could not get blade cli jar from repository." );
+	        }
+	    }
+
+		def bladeclijar = cliJar.getName();
+
+		executeBlade(new String[]{'server','start', '-b'});
+
+		OkHttpClient client = new OkHttpClient()
+		Request request = new Builder().url("http://localhost:8080").build()
+
+		boolean pingSucceeded = false
+
+		while (!pingSucceeded) {
+			try {
+				client.newCall(request).execute()
+				pingSucceeded = true
+			}
+			catch( Exception e) {
+			}
+		}
+	}
+
+	def "verify all blade samples"() {
+		given:
+			FileTree bladeSampleOutputFiles = fileTree(dir: 'modules/', include: '**/libs/*.jar')
+
+			def sampleBundles = bladeSampleOutputFiles.files
+			def sampleBundle = sampleBundles.name
+			def bundleIDAllList = []
+			def bundleIDStartList = []
+			def errorList = []
+
+		when:
+			sampleBundles.each { sampleBundlefile ->
+				def installBundleOutput = executeBlade(new String[]{'sh', 'install', "file:${sampleBundlefile}"}).text()
+
+				def bundleID = installBundleOutput.substring(installBundleOutput.length() - 3)
+
+				if(installBundleOutput.contains("Failed") {
+					throw new GradleException(installBundleOutput)
+				}
+
+				bundleIDAllList.add(bundleID)
+
+				def jarManifest = new aQute.bnd.osgi.Jar(sampleBundlefile).getmanifest().getMainAttributes();
+
+				if (jarManifest.getValue('fragment-Host') == null) {
+					bundleIDStartList.add(bundleID)
+				}
+
+				bundleIDAllList = bundleIDAllList.unique()
+				bundleIDStartList = bundleIDStartList.unique()
+			}
+
+			bundleIDStartList.each { startBundleID ->
+				def startOutput = executeBlade(new String[]{'sh', 'start', startBundleID}).text()
+
+				if (startOutput.contains('Exception')) {
+					errorList.add(startOutput)
+				}
+			}
+
+		then:
+			// check the list for error status
+
+			//result.errorList.isEmpty == true
+			assert(errorList.isEmpty());
+			noExceptionThrown()
+
+		cleanup:
+			bundleIDAllList.each { bundleIDAll ->
+				def uninstallOutput = executeBlade(new String[]{'sh', 'uninstall', bundleIDAll}).text()
+			}
+	}
+
+	def "verify new blade template projects"() {
+
+	}
+	def teardown(){
+		doLast {
+			executeBlade(new String[]{'server', 'stop'})
+		}
+	}
+
+}


### PR DESCRIPTION
I'm getting compile errors from the code that checks for the bladeCLIJar 

```
:tests:compileTestGroovy
startup failed:
/opt/dev/projects/github/liferay-blade-samples/liferay-workspace/tests/src/test/groovy/com/liferay/blade/tests/BladeTests.groovy: 31: Apparent variable 'repoCache' was found in a static scope but doesn't refer to a local variable, static field or class. Possible causes:
You attempted to reference a variable in the binding or an instance variable from a static context.
You misspelled a classname or statically imported field. Please check the spelling.
You attempted to use a method 'repoCache' but left out brackets in a place not allowed by the grammar.
 @ line 31, column 50.
    FixedIndexedRepo.PROP_CACHE, repoCache.
                                 ^

/opt/dev/projects/github/liferay-blade-samples/liferay-workspace/tests/src/test/groovy/com/liferay/blade/tests/BladeTests.groovy: 42: Apparent variable 'cachedBladeCLIPath' was found in a static scope but doesn't refer to a local variable, static field or class. Possible causes:
You attempted to reference a variable in the binding or an instance variable from a static context.
You misspelled a classname or statically imported field. Please check the spelling.
You attempted to use a method 'cachedBladeCLIPath' but left out brackets in a place not allowed by the grammar.
 @ line 42, column 14.
                cachedBladeCLIPath = new Path( cliJar.getCanonicalPath() );
```
