### PR TITLE
Core JSP Hook Docs

### DIFF
--- a/liferay-gradle/blade.corejsphook/README.markdown
+++ b/liferay-gradle/blade.corejsphook/README.markdown
@@ -1,0 +1,25 @@
+# Core JSP Hook
+
+The Core JSP Hook sample lets you override core/kernel JSPs by adding them to
+the module's `META-INF/jsps` folder. This module overrides the `bottom.jsp` file
+by inserting the `bottom-ext.jsp` file in the `META-INF/jsps/html/common/themes`
+folder. When deploying this sample with no customizations, sample text is added
+to the bottom of Liferay's default theme. For more information on how to
+customize Liferay's Core using JSP hooks, visit the
+[Overriding Core JSPs](https://dev.liferay.com/develop/tutorials/-/knowledge_base/7-0/overriding-core-jsps)
+tutorial.
+
+![Figure 1: Deploying a core JSP hook overrides core functionality, like Liferay's default theme.](https://github.com/codyhoag/liferay-docs/blob/blade-sample-images/develop/tutorials/blade-images/blade-core-jsp-hook.png)
+
+**Note:** Using core JSP hooks should be a last resort option only when there is
+no other way to customize functionality in your Liferay installation. It's up to
+the maintainer of this JSP hook to properly maintain and adapt to changes in the
+underlying JSP implementation.
+
+You can easily modify this sample by customizing its `BladeCustomJspBag` Java
+class or adding additional JSPs in the configured JSP folder. You can modify the
+custom JSP folder's path by editing the `BladeCustomJspBag.getCustomJspDir()`
+method to return a different folder path.
+
+For more information on customizing the Core JSP Hook sample to fit your needs,
+see the Javadoc listed in this sample's `BladeCustomJspBag` class.

--- a/liferay-gradle/blade.corejsphook/src/main/java/com/liferay/blade/samples/corejsphook/BladeCustomJspBag.java
+++ b/liferay-gradle/blade.corejsphook/src/main/java/com/liferay/blade/samples/corejsphook/BladeCustomJspBag.java
@@ -33,22 +33,53 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 
 /**
+ * Represents a custom JSP bag used to override Liferay's core JSPs. This class
+ * sets the following properties:
+ *
+ * <ul>
+ * <li>
+ * <code>context.id</code>: the custom JSP bag class name
+ * </li>
+ * <li>
+ * <code>context.name</code>: the human readable name for you service
+ * </li>
+ * <li>
+ * <code>service.ranking</code>: the priority of your implementation. The
+ * importance of your change dictates its service ranking. For example, if
+ * another custom JSP bag implementation overriding the same JSP is deployed
+ * with a service rank of <code>101</code>, it takes precedence over this one
+ * because its service ranking is higher.
+ * </li>
+ * </ul>
+ *
  * @author Liferay
  */
 @Component(
 	immediate = true,
 	property = {
-		"context.id=BladeCustomJspBag", "context.name=Test Custom JSP Bag",
+		"context.id=BladeCustomJspBag",
+		"context.name=Test Custom JSP Bag",
 		"service.ranking:Integer=100"
 	}
 )
 public class BladeCustomJspBag implements CustomJspBag {
 
+	/**
+	 * Returns the directory path in the module JAR where the custom JSPs
+	 * reside.
+	 *
+	 * @return the directory path in the module JAR where the custom JSPs reside
+	 */
 	@Override
 	public String getCustomJspDir() {
 		return "META-INF/jsps/";
 	}
 
+	/**
+	 * Returns the custom JSP URL paths.
+	 *
+	 * @return the custom JSP URL paths
+	 */
 	@Override
 	public List<String> getCustomJsps() {
 		return _customJsps;
@@ -64,6 +95,13 @@ public class BladeCustomJspBag implements CustomJspBag {
 		return true;
 	}
 
+	/**
+	 * Adds the URL paths for all custom core JSPs to a list when the module is
+	 * activated.
+	 *
+	 * @param bundleContext the bundle context from which to get the custom
+	 *        JSP's bundle
+	 */
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_bundle = bundleContext.getBundle();


### PR DESCRIPTION
This provides a README and partial Javadocs for the `blade.corejsphook` sample. I'll work on getting more info so I can fully document the `BladeCustomJspBag` class. Still unclear on a few methods.

Thanks for the comments, @olafk. They helped me steer in the right direction!