### PR TITLE
blade.indexerpostprocessor - Update BlogsIndexerPP

### DIFF
--- a/liferay-workspace/modules/blade.indexerpostprocessor/src/main/java/com/liferay/blade/samples/indexerpostprocessor/BlogsIndexerPostProcessor.java
+++ b/liferay-workspace/modules/blade.indexerpostprocessor/src/main/java/com/liferay/blade/samples/indexerpostprocessor/BlogsIndexerPostProcessor.java
@@ -32,7 +32,10 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	immediate = true,
-	property = {"indexer.class.name=com.liferay.blogs.kernel.model.BlogsEntry"},
+	property = {
+		"indexer.class.name=com.liferay.blogs.kernel.model.BlogsEntry",
+		"indexer.class.name=com.liferay.blogs.model.BlogsEntry"
+	},
 	service = IndexerPostProcessor.class
 )
 public class BlogsIndexerPostProcessor implements IndexerPostProcessor {

--- a/liferay-workspace/modules/blade.indexerpostprocessor/src/main/resources/META-INF/module-log4j.xml
+++ b/liferay-workspace/modules/blade.indexerpostprocessor/src/main/resources/META-INF/module-log4j.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+	<category name="com.liferay.blade.samples.indexerpostprocessor">
+		<priority value="INFO" />
+	</category>
+</log4j:configuration>


### PR DESCRIPTION
Hi Greg,

The BlogsEntry model has been modularized since the release into blogs-api so on the latest master or DXP Fix Packs, the BlogsEntryIndexer registers itself for `com.liferay.blogs.model.BlogsEntry` not for `com.liferay.blogs.kernel.model.BlogsEntry`.

I also configured logging for the module.

Cheers,
Tibor