### PR TITLE
Give SB portlet a display name

### DIFF
--- a/liferay-gradle/blade.hook.resourcebundle/src/main/resources/content/Language_en.properties
+++ b/liferay-gradle/blade.hook.resourcebundle/src/main/resources/content/Language_en.properties
@@ -1,1 +1,1 @@
-add-blog-entry=Overriden Add Blog Entry
+add-blog-entry=Overridden Add Blog Entry

--- a/liferay-gradle/blade.servicebuilder.web/src/main/java/com/liferay/blade/samples/servicebuilder/web/JSPPortlet.java
+++ b/liferay-gradle/blade.servicebuilder.web/src/main/java/com/liferay/blade/samples/servicebuilder/web/JSPPortlet.java
@@ -48,6 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"com.liferay.portlet.display-category=category.sample",
 		"com.liferay.portlet.instanceable=true",
+		"javax.portlet.display-name=Service Builder",
 		"javax.portlet.init-param.template-path=/",
 		"javax.portlet.init-param.view-template=/view.jsp",
 		"javax.portlet.name=com_liferay_blade_samples_servicebuilder_web",

--- a/liferay-workspace/modules/blade.hook.resourcebundle/src/main/resources/content/Language_en.properties
+++ b/liferay-workspace/modules/blade.hook.resourcebundle/src/main/resources/content/Language_en.properties
@@ -1,1 +1,1 @@
-add-blog-entry=Overriden Add Blog Entry
+add-blog-entry=Overridden Add Blog Entry

--- a/liferay-workspace/modules/blade.servicebuilder.web/src/main/java/com/liferay/blade/samples/servicebuilder/web/JSPPortlet.java
+++ b/liferay-workspace/modules/blade.servicebuilder.web/src/main/java/com/liferay/blade/samples/servicebuilder/web/JSPPortlet.java
@@ -48,6 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"com.liferay.portlet.display-category=category.sample",
 		"com.liferay.portlet.instanceable=true",
+		"javax.portlet.display-name=Service Builder",
 		"javax.portlet.init-param.template-path=/",
 		"javax.portlet.init-param.view-template=/view.jsp",
 		"javax.portlet.name=com_liferay_blade_samples_servicebuilder_web",

--- a/maven/blade.hook.resourcebundle/src/main/resources/content/Language_en.properties
+++ b/maven/blade.hook.resourcebundle/src/main/resources/content/Language_en.properties
@@ -1,1 +1,1 @@
-add-blog-entry=Overriden Add Blog Entry
+add-blog-entry=Overridden Add Blog Entry

--- a/maven/blade.servicebuilder.web/src/main/java/com/liferay/blade/samples/servicebuilder/web/JSPPortlet.java
+++ b/maven/blade.servicebuilder.web/src/main/java/com/liferay/blade/samples/servicebuilder/web/JSPPortlet.java
@@ -48,6 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"com.liferay.portlet.display-category=category.sample",
 		"com.liferay.portlet.instanceable=true",
+		"javax.portlet.display-name=Service Builder",
 		"javax.portlet.init-param.template-path=/",
 		"javax.portlet.init-param.view-template=/view.jsp",
 		"javax.portlet.name=com_liferay_blade_samples_servicebuilder_web",


### PR DESCRIPTION
Currently, the Service Builder portlet is very difficult to find in the App menu, due to it having no display name. I've added a display name so it's easier to find and matches other Blade portlets.