### PR TITLE
Properly comment out copyright message in JDBC/JNDI Service Builder JSPs

### DIFF
--- a/gradle/apps/service-builder/jdbc/jdbc-web/src/main/resources/META-INF/resources/init.jsp
+++ b/gradle/apps/service-builder/jdbc/jdbc-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,3 +1,4 @@
+<%--
 /**
  * Copyright 2000-present Liferay, Inc.
  *
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+--%>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 

--- a/gradle/apps/service-builder/jdbc/jdbc-web/src/main/resources/META-INF/resources/view.jsp
+++ b/gradle/apps/service-builder/jdbc/jdbc-web/src/main/resources/META-INF/resources/view.jsp
@@ -1,3 +1,4 @@
+<%--
 /**
  * Copyright 2000-present Liferay, Inc.
  *
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+--%>
 
 <%@ include file="/init.jsp" %>
 

--- a/gradle/apps/service-builder/jndi/jndi-web/src/main/resources/META-INF/resources/init.jsp
+++ b/gradle/apps/service-builder/jndi/jndi-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,3 +1,4 @@
+<%--
 /**
  * Copyright 2000-present Liferay, Inc.
  *
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+--%>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 

--- a/gradle/apps/service-builder/jndi/jndi-web/src/main/resources/META-INF/resources/view.jsp
+++ b/gradle/apps/service-builder/jndi/jndi-web/src/main/resources/META-INF/resources/view.jsp
@@ -1,3 +1,4 @@
+<%--
 /**
  * Copyright 2000-present Liferay, Inc.
  *
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+--%>
 
 <%@ include file="/init.jsp" %>
 


### PR DESCRIPTION
Copyrights are currently viewable from the portlet's UI. This text should be properly commented out so it is not rendered in the view.