### PR TITLE
LRDOCS-4146 Fix Kotlin Portlet Blade Sample

### DIFF
--- a/gradle/apps/kotlin-portlet/bnd.bnd
+++ b/gradle/apps/kotlin-portlet/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-SymbolicName: com.liferay.blade.kotlin.portlet
 Bundle-Version: 1.0.0
 Import-Package:\
 	!kotlin,\
-	\
+	!kotlin.*,\
 	*
 -sources: true

--- a/gradle/apps/kotlin-portlet/src/main/kotlin/com/liferay/blade/samples/portlet/kotlin/KotlinGreeterActionCommandKt.kt
+++ b/gradle/apps/kotlin-portlet/src/main/kotlin/com/liferay/blade/samples/portlet/kotlin/KotlinGreeterActionCommandKt.kt
@@ -56,7 +56,7 @@ class KotlinGreeterActionCommandKt : MVCActionCommand {
 			_log.info("Hello " + name)
 		}
 
-		val greetingMessage = "Hello $name! Welcome to OSGi"
+		val greetingMessage = "Hello $name!"
 
 		actionRequest?.setAttribute("GREETER_MESSAGE", greetingMessage)
 

--- a/gradle/apps/kotlin-portlet/src/main/kotlin/com/liferay/blade/samples/portlet/kotlin/KotlinGreeterPortletKt.kt
+++ b/gradle/apps/kotlin-portlet/src/main/kotlin/com/liferay/blade/samples/portlet/kotlin/KotlinGreeterPortletKt.kt
@@ -34,7 +34,7 @@ import org.osgi.service.component.annotations.Component
 		"javax.portlet.display-name=Kotlin Greeter Portlet",
 		"javax.portlet.init-param.template-path=/",
 		"javax.portlet.init-param.view-template=/view.jsp",
-    "javax.portlet.name=KotlinGreeterPortletKt",
+		"javax.portlet.name=KotlinGreeterPortletKt",
 		"javax.portlet.security-role-ref=power-user,user"
 	),
 	service = arrayOf(Portlet::class))

--- a/gradle/apps/kotlin-portlet/src/main/resources/META-INF/resources/view.jsp
+++ b/gradle/apps/kotlin-portlet/src/main/resources/META-INF/resources/view.jsp
@@ -18,7 +18,14 @@
 
 <%@ include file="/init.jsp" %>
 
-<%= renderRequest.getAttribute("GREETER_MESSAGE") %>
+<%
+String greeting = (String)renderRequest.getAttribute("GREETER_MESSAGE");
+if (greeting == null) {
+	greeting = "";
+}
+%>
+
+<%= greeting %>
 
 <liferay-ui:message key="blade_portlet_kotlinactioncommand_KotlinGreeterPortlet.caption" />
 

--- a/gradle/apps/kotlin-portlet/src/main/resources/content/Language.properties
+++ b/gradle/apps/kotlin-portlet/src/main/resources/content/Language.properties
@@ -1,1 +1,1 @@
-blade_portlet_kotlinactioncommand_KotlinGreeterPortlet.caption=Hello from Kotlin Portlet!
+blade_portlet_kotlinactioncommand_KotlinGreeterPortlet.caption=Welcome to the OSGi Kotlin Portlet!


### PR DESCRIPTION
The current version of the Kotlin portlet does not activate when deployed to Liferay Portal. I fixed this by excluding `kotlin.*` packages in the `bnd.bnd`. See [LRDOCS-4146](https://issues.liferay.com/browse/LRDOCS-4146) for details on issue. I also...

- Edited the `view.jsp` to avoid printing `null` to the main screen.
- Cleaned up the printed message.
- Fixed a tiny source formatting inconsistency.

Thanks!