### PR TITLE
2.xforCNQATests

### DIFF
--- a/liferay-workspace/tests/blade.samples.integration.test/build.gradle
+++ b/liferay-workspace/tests/blade.samples.integration.test/build.gradle
@@ -64,7 +64,7 @@ testIntegration {
 
 	}
 
-	systemProperty 'bladeURL', System.getProperty('bladeURL', "https://releases.liferay.com/tools/blade-cli/latest/blade.jar")
+	systemProperty 'bladeURL', System.getProperty('bladeURL', "https://releases.liferay.com/tools/blade-cli/2.x/blade.jar")
 }
 
 stopTestableTomcat {

--- a/liferay-workspace/tests/blade.samples.test/build.gradle
+++ b/liferay-workspace/tests/blade.samples.test/build.gradle
@@ -91,7 +91,7 @@ task testFunctional(type: Test) {
 		systemProperty 'renderCommandPortletJarFile', project(':modules:blade.portlet.rendercommand').jar.archivePath
 	}
 
-	systemProperty 'bladeURL', System.getProperty('bladeURL', "https://releases.liferay.com/tools/blade-cli/latest/blade.jar")
+	systemProperty 'bladeURL', System.getProperty('bladeURL', "https://releases.liferay.com/tools/blade-cli/2.x/blade.jar")
 
 	doLast {
 		delete new File("blade.jar")

--- a/liferay-workspace/tests/blade.servicebuilder.test/build.gradle
+++ b/liferay-workspace/tests/blade.servicebuilder.test/build.gradle
@@ -47,7 +47,7 @@ task testFunctional(type: Test) {
 	dependsOn ":modules:blade.servicebuilder.svc:jar"
 	dependsOn ":modules:blade.servicebuilder.web:jar"
 
-	systemProperty 'bladeURL', System.getProperty('bladeURL', "https://releases.liferay.com/tools/blade-cli/latest/blade.jar")
+	systemProperty 'bladeURL', System.getProperty('bladeURL', "https://releases.liferay.com/tools/blade-cli/2.x/blade.jar")
 	systemProperty 'fooApiJarFile', project(":modules:blade.servicebuilder.api").jar.archivePath
 	systemProperty 'fooServiceJarFile', project(":modules:blade.servicebuilder.svc").jar.archivePath
 	systemProperty 'fooWebJarFile', project(":modules:blade.servicebuilder.web").jar.archivePath


### PR DESCRIPTION
These tests are failing for CNQA because of `java.lang.Exception: Expecting bladejar with major version 2, found version: 3`

So i'm reverting it back to 2.x. I want to eventually move them to 3.x of blade, but maybe after Vernon can help me getting more stable front end test results