### PR TITLE
Fix language key syntax for ScreenName Validator sample

### DIFF
--- a/gradle/extensions/screen-name-validator/src/main/resources/content/Language.properties
+++ b/gradle/extensions/screen-name-validator/src/main/resources/content/Language.properties
@@ -1,1 +1,1 @@
-custom.screen.name= ScreenName Validator
+custom-screen-name= ScreenName Validator


### PR DESCRIPTION
This allows the name to be properly displayed.