### PR TITLE
Update simple-theme sample to use latest Theme Builder

### DIFF
--- a/gradle/themes/simple-theme/build.gradle
+++ b/gradle/themes/simple-theme/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	dependencies {
 		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.theme.builder", version: "latest.release"
-		classpath group: "com.liferay", name: "com.liferay.portal.tools.theme.builder", version: "1.1.1"
+		classpath group: "com.liferay", name: "com.liferay.portal.tools.theme.builder", version: "latest.release"
 	}
 }
 
@@ -13,5 +13,5 @@ dependencies {
 
 	portalCommonCSS group: "com.liferay", name: "com.liferay.frontend.css.common", version: "2.0.4"
 
-	themeBuilder group: "com.liferay", name: "com.liferay.portal.tools.theme.builder", version: "1.1.1"
+	themeBuilder group: "com.liferay", name: "com.liferay.portal.tools.theme.builder", version: "1.1.5"
 }

--- a/liferay-workspace/wars/simple-theme/build.gradle
+++ b/liferay-workspace/wars/simple-theme/build.gradle
@@ -13,5 +13,5 @@ dependencies {
 
 	portalCommonCSS group: "com.liferay", name: "com.liferay.frontend.css.common", version: "2.0.4"
 
-	themeBuilder group: "com.liferay", name: "com.liferay.portal.tools.theme.builder", version: "1.1.1"
+	themeBuilder group: "com.liferay", name: "com.liferay.portal.tools.theme.builder", version: "1.1.5"
 }

--- a/maven/themes/simple-theme/pom.xml
+++ b/maven/themes/simple-theme/pom.xml
@@ -63,7 +63,7 @@
 			<plugin>
 				<groupId>com.liferay</groupId>
 				<artifactId>com.liferay.portal.tools.theme.builder</artifactId>
-				<version>1.1.1</version>
+				<version>1.1.5</version>
 				<executions>
 					<execution>
 						<phase>generate-resources</phase>


### PR DESCRIPTION
This allows the `simple-theme` sample to be deployable to Liferay 7.1. However, we still have issues with the outdated frontend theme dependencies in both our updated `theme` project template and this sample. These cause the themes to display wrong.