### PR TITLE
Override valid originalModule version in Ext sample

### DIFF
--- a/gradle/ext/login-web-ext/build.gradle
+++ b/gradle/ext/login-web-ext/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 
-	originalModule group: "com.liferay", name: "com.liferay.login.web", version: "2.0.4"
+	originalModule group: "com.liferay", name: "com.liferay.login.web", version: "3.0.4"
 }

--- a/gradle/extensions/document-action/src/main/java/blade/document/action/configurationicon/BladeActionConfigurationIcon.java
+++ b/gradle/extensions/document-action/src/main/java/blade/document/action/configurationicon/BladeActionConfigurationIcon.java
@@ -83,6 +83,7 @@ public class BladeActionConfigurationIcon extends BasePortletConfigurationIcon {
 		String version = fileEntry.getVersion();
 		String createdDate = String.valueOf(fileEntry.getCreateDate());
 		String createdUserName = fileEntry.getUserName();
+
 		String statusLabel = null;
 
 		try {

--- a/gradle/extensions/document-action/src/main/java/blade/document/action/displaycontext/BladeActionDisplayContext.java
+++ b/gradle/extensions/document-action/src/main/java/blade/document/action/displaycontext/BladeActionDisplayContext.java
@@ -121,6 +121,7 @@ public class BladeActionDisplayContext
 		String fileName = fileVersion.getFileName();
 		String mimeType = fileVersion.getMimeType();
 		String version = fileVersion.getVersion();
+
 		Date date = fileVersion.getCreateDate();
 
 		String createdDate = date.toString();


### PR DESCRIPTION
This was fixed for the `liferay-workspace` version of the sample, but was not applied to the `gradle` version.